### PR TITLE
Remove ID property and enforce unique action types

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,18 +126,17 @@ const bestAction = createAction('Best. Action. Ever.', (text, checked)=> ({text,
 
 When calling an action creator, the returned object will have the following properties:
 
-- `__id__`: a generated id. Used by the reducers. Don't touch it.
 - `type`: totally useless for you, but provide support for devtools.
 - `payload`: the data passed when calling the action creator. Will be the first argument of the function except if you specified a payload reducer when creating the action.
 
 ```javascript
 const addTodo = createAction('Add todo');
 addTodo('content');
-// return { __id__: 1, type: '[1] Add todo', payload: 'content' }
+// return { type: 'Add todo', payload: 'content' }
 
 const editTodo = createAction('Edit todo', (id, content)=> ({id, content}));
 editTodo(42, 'the answer');
-// return { __id__: 2, type: '[2] Edit todo', payload: {id: 42, content: 'the answer'} }
+// return { type: 'Edit todo', payload: {id: 42, content: 'the answer'} }
 ```
 
 Remember that you still need to dispatch those actions. If you already have one or more stores, you can bind the action to them so it will be automatically dispatched using the `bindTo` function. Notice that each call to `bindTo` will override any previous call.
@@ -186,7 +185,7 @@ const reducerFactory = createReducer(function (on) {
 }, 0);
 ```
 
-Since an action is an object with some metadata (`__id__` and `type`) and a `payload` (which is your actual data), all reduce functions directly take the payload as their 2nd argument by default rather than the whole action since all other properties are handled by the lib and you shouldn't care about them anyway. If you really need to use the full action, you can change the behavior of a reducer.
+Since an action is an object with some metadata (`type`) and a `payload` (which is your actual data), all reduce functions directly take the payload as their 2nd argument by default rather than the whole action since all other properties are handled by the lib and you shouldn't care about them anyway. If you really need to use the full action, you can change the behavior of a reducer.
 
 ```javascript
 const add = createAction();

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,0 @@
-export const ID = '__id__';

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -1,6 +1,6 @@
-import { ID } from './constants';
 
 let id = 0;
+let types = {};
 
 const identity = arg => arg;
 
@@ -14,16 +14,24 @@ export default function createAction(name, mapper = identity) {
     mapper = identity;
   }
 
+  if (name == null) {
+    name = (++id).toString();
+  }
+
+  if (types.hasOwnProperty(name)) {
+    throw new Error('Duplicate action type: ' + name);
+  }
+
+  types[name] = null;
+
   const action = {
-    id: ++id,
-    type: `[${id}]${name ? ' ' + name : ''}`
+    type: name
   };
 
   let actionStores = undefined;
 
   function setupPayload(payload) {
     return {
-      [ID]: action.id,
       type: action.type,
       payload: payload
     };
@@ -41,7 +49,7 @@ export default function createAction(name, mapper = identity) {
     }
   }
 
-  actionCreator.toString = ()=> action.id;
+  actionCreator.toString = ()=> action.type;
 
   actionCreator.bindTo = (stores)=> {
     actionStores = stores;

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -1,5 +1,3 @@
-import { ID } from './constants';
-
 export default function createReducer(handlers = {}, defaultState) {
   let opts = {
     payload: true
@@ -24,8 +22,8 @@ export default function createReducer(handlers = {}, defaultState) {
   }
 
   function reduce(state = defaultState, action) {
-    if (action[ID] && handlers[action[ID]]) {
-      return handlers[action[ID]](state, opts.payload ? action.payload : action);
+    if (action.type && handlers[action.type]) {
+      return handlers[action.type](state, opts.payload ? action.payload : action);
     } else {
       return state;
     }

--- a/test/createActionTest.js
+++ b/test/createActionTest.js
@@ -1,7 +1,6 @@
 import chai from 'chai';
 import {createStore} from 'redux';
 import {createAction, createReducer} from '../src/index';
-import { ID } from '../src/constants';
 const expect = chai.expect;
 
 describe('createAction', function () {
@@ -15,12 +14,11 @@ describe('createAction', function () {
 
   function testAction(action, payload, description) {
     expect(action).to.be.an('object');
-    expect(action).to.have.all.keys(ID, 'type', 'payload');
-    expect(action[ID]).to.be.a('number');
+    expect(action).to.have.all.keys('type', 'payload');
     expect(action.type).to.be.a('string');
     expect(action.payload).to.deep.equal(payload);
     if (description !== undefined) {
-      expect(action.type).to.have.string(description);
+      expect(action.type).to.equal(description);
     }
   }
 
@@ -59,6 +57,19 @@ describe('createAction', function () {
   it('should return a valid action again', function () {
     const action = firstAction('a string');
     testAction(action, 'a string');
+  });
+
+  it('should create two empty action creator', function () {
+    const action1 = createAction();
+    const action2 = createAction();
+    expect(action1.toString()).to.not.equal(action2.toString())
+  });
+
+  it('should not create duplicate action creator', function () {
+    const action1 = createAction('the action');
+    expect(() => {
+      const action2 = createAction('the action');
+    }).to.throw('Duplicate action type: the action');
   });
 
   it('should create a second action creator', function () {

--- a/test/readmeTest.js
+++ b/test/readmeTest.js
@@ -1,7 +1,6 @@
 import chai from 'chai';
 import {createStore, combineReducers} from 'redux';
 import {bindAll, createAction, createReducer} from '../src/index';
-import { ID } from '../src/constants';
 const expect = chai.expect;
 
 describe('README', function () {
@@ -73,17 +72,15 @@ describe('README', function () {
   it('should validate createAction API', function () {
     const addTodo = createAction('Add todo');
     addTodo('content');
-    // return { __id__: 1, type: '[1] Add todo', payload: 'content' }
+    // return { type: 'Add todo', payload: 'content' }
     const addTodoAction = addTodo('content');
-    expect(addTodoAction[ID]).to.be.a('number');
     expect(addTodoAction.type).to.be.a('string');
     expect(addTodoAction.payload).to.deep.equal('content');
 
     const editTodo = createAction('Edit todo', (id, content)=> ({id, content}));
     editTodo(42, 'the answer');
-    // return { __id__: 2, type: '[2] Edit todo', payload: {id: 42, content: 'the answer'} }
+    // return { type: 'Edit todo', payload: {id: 42, content: 'the answer'} }
     const editTodoAction = editTodo(42, 'the answer');
-    expect(editTodoAction[ID]).to.be.a('number');
     expect(editTodoAction.type).to.be.a('string');
     expect(editTodoAction.payload).to.deep.equal({id: 42, content: 'the answer'});
 


### PR DESCRIPTION
I like how redux-act allows to use action creators themselves as keys  for createReducer configuration object (thanks to its toString implementation), and also to use them in other places without the need of magic strings or defining and importing constants.

Now I would like to share actions definitions between client and server. My scenario is very similar to the one explained in [this tutorial](http://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html) (in particular, see [this](http://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html#receiving-remote-redux-actions) and [this](http://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html#sending-actions-to-the-server-using-redux-middleware)).

The problem is that using redux-act the action types are non-deterministic because they depend on a runtime generated id, being inconsistent between client and server.

This pull request keeps the ability of autogenerating action types (++id) when not specified, but also enforces that, when specified, it's unique and can be used as a deterministic, consistent value between client and server.