### PR TITLE
FSA compatibility

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,0 @@
-export const ID = '__id__';

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -1,5 +1,3 @@
-import { ID } from './constants';
-
 let id = 0;
 
 const types = {}
@@ -50,15 +48,13 @@ export default function createAction(description, payloadReducer, metaReducer) {
   }
 
   const action = {
-    id: isSerializable ? description : ++id,
-    type: isSerializable ? description : `[${id}]${description ? ' ' + description : ''}`
+    type: isSerializable ? description : `[${++id}]${description ? ' ' + description : ''}`
   };
 
   let dispatchFunctions = undefined;
 
   function makeAction(...args) {
     return {
-      [ID]: action.id,
       type: action.type,
       payload: payloadReducer(...args),
       meta: metaReducer(...args)
@@ -80,7 +76,7 @@ export default function createAction(description, payloadReducer, metaReducer) {
     return makeAndDispatch(dispatchFunctions)(...args);
   }
 
-  actionCreator.toString = () => action.id;
+  actionCreator.toString = () => action.type;
 
   actionCreator.raw = makeAction;
 

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -1,4 +1,3 @@
-import { ID } from './constants';
 import batch from './batch';
 
 export default function createReducer(handlers = {}, defaultState) {
@@ -39,11 +38,11 @@ export default function createReducer(handlers = {}, defaultState) {
   }
 
   function reduce(state = defaultState, action) {
-    if (action[ID] && handlers[action[ID]]) {
+    if (action.type && handlers[action.type]) {
       if (opts.payload) {
-        return handlers[action[ID]](state, action.payload, action.meta);
+        return handlers[action.type](state, action.payload, action.meta);
       } else {
-        return handlers[action[ID]](state, action);
+        return handlers[action.type](state, action);
       }
     } else {
       return state;


### PR DESCRIPTION
The `createAction` function creates and action with the `__id__` property, which makes the action not an FSA (https://github.com/acdlite/flux-standard-action), meaning it can't be used with middlewares such as `redux-promise`

Would it be a good idea to drop the `__id__` property, and use `type` in its place?

