### PR TITLE
add createActionAsync

### DIFF
--- a/src/createActionAsync.js
+++ b/src/createActionAsync.js
@@ -1,0 +1,30 @@
+import createAction from './createAction'
+
+export default function createActionAsync(description, api, options = {}) {
+
+  let actions = {
+    request: createAction(`${description}_REQUEST`, options.payloadReducer, options.metaReducer),
+    ok: createAction(`${description}_OK`, options.payloadReducer, options.metaReducer),
+    error: createAction(`${description}_ERROR`, options.payloadReducer, options.metaReducer)
+  }
+
+  let actionAsync = (payload) => {
+    return (dispatch) => {
+      dispatch(actions.request(payload));
+      return api(payload)
+      .then(res => {
+        dispatch(actions.ok(res))
+      })
+      .catch(err => {
+        dispatch(actions.error(err))
+        throw err;
+      })
+    }
+  }
+
+  actionAsync.request = actions.request;
+  actionAsync.ok = actions.ok;
+  actionAsync.error = actions.error;
+  return actionAsync;
+
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { default as createAction} from './createAction';
+export { default as createActionAsync} from './createActionAsync';
 export { default as createReducer} from './createReducer';
 export { default as assignAll} from './assignAll';
 export { default as bindAll} from './bindAll';

--- a/test/createActionAsyncTest.js
+++ b/test/createActionAsyncTest.js
@@ -1,0 +1,67 @@
+import chai, {assert} from 'chai';
+import spies from 'chai-spies';
+import thunk from 'redux-thunk'
+import {createStore, applyMiddleware} from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import {createActionAsync, createReducer} from '../src/index';
+const expect = chai.expect;
+chai.use(spies);
+
+describe.only('createActionAsync', function () {
+  let actionName = 'LOGIN';
+
+  it('should support all format', function () {
+    let actionName = 'LOGIN_1';
+    const login = createActionAsync(actionName, () => Promise.resolve());
+    expect(login).to.be.a('function');
+    //expect(login.run).to.be.a('function');
+    expect(login.request).to.be.a('function');
+    expect(login.ok).to.be.a('function');
+    expect(login.error).to.be.a('function');
+  });
+  it('run the action, ok', function () {
+    let actionName = 'LOGIN_2';
+    let user = {id: 8};
+    function apiOk(){
+      return Promise.resolve(user);
+    }
+    const login = createActionAsync(actionName, apiOk);
+    const initialState = {
+      authenticated: false,
+    };
+
+    let reducer = createReducer({
+      [login.request]: (state, payload) => {
+        console.log('login.request ', payload);
+      },
+      [login.ok]: (state, payload) => {
+        console.log('login.ok ', payload);
+      },
+      [login.error]: (state, payload) => {
+        console.log('login.error ', payload);
+      }
+    }, initialState);
+
+    let run = login({username:'lolo', password: 'password'});
+
+    const store = createStore(reducer, applyMiddleware(thunk));
+
+    store.dispatch(run);
+
+  });
+  it('run the action, ko', function () {
+    let actionName = 'LOGIN_3';
+    let error = {name: 'myError'};
+    function apiError(){
+      return Promise.reject(error);
+    }
+    const login = createActionAsync(actionName, apiError);
+    let run = login({username:'lolo', password: 'password'});
+    function dispatch(action){
+      console.log('dispatch action: ', action);
+      //assert.equal(action.type, `${actionName}_ERROR`)
+      //assert.equal(action.payload, error);
+    }
+    run(dispatch);
+  });
+});

--- a/test/loggers/reduxLogger.js
+++ b/test/loggers/reduxLogger.js
@@ -9,6 +9,7 @@ const spy = chai.spy.on(console, 'log');
 
 describe('loggers > redux logger', function () {
   it('should log actions', function () {
+    spy.reset();
     const reducer = function () {};
     const logger = createLogger({ logger: console });
     const store = applyMiddleware(logger)(createStore)(reducer);


### PR DESCRIPTION
This PR adds the function `createActionAsync `  which creates an asynchronous action. This avoids writing a lot a boilerplate code.
There is definitely room for improvements regarding testing and doc but I would like to make sure you are willing to integrate this change before.