### PR TITLE
add error key when argument is a instance of Error

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -49,17 +49,21 @@ export default function createAction(description, payloadReducer, metaReducer) {
   let dispatchFunctions = undefined;
 
   function makeAction(...args) {
+    const error = args[0] instanceof Error ? { error: true } : {};
+
     if (metaReducer) {
       return {
         type,
         payload: payloadReducer(...args),
-        meta: metaReducer(...args)
+        meta: metaReducer(...args),
+        ...error
       };
     }
 
     return {
       type,
-      payload: payloadReducer(...args)
+      payload: payloadReducer(...args),
+      ...error,
     };
   }
 

--- a/test/createActionTest.js
+++ b/test/createActionTest.js
@@ -27,6 +27,10 @@ describe('createAction', function () {
       expect(action).to.contain.keys('meta');
       expect(action.meta).to.deep.equal(meta);
     }
+    if (payload instanceof Error) {
+      expect(action).to.contain.keys('error');
+      expect(action.error).to.equal(true);
+    }
   }
 
   function testSerializableAction(action, description, payload, meta) {
@@ -390,4 +394,16 @@ describe('createAction', function () {
     testAction(boundAction.raw(1), 1);
     expect(store.getState()).to.equal(0);
   });
+
+  it('should add error key', function () {
+    const action = createAction();
+    const actionWithMeta = createAction(x => x, x => ({more: true, content: x}));
+    const error = new Error('Simple error');
+
+    const errorAction = action(error);
+    const errorActionMeta = actionWithMeta(error);
+
+    testAction(errorAction, error);
+    testAction(errorActionMeta, error);
+  })
 });


### PR DESCRIPTION
implements https://github.com/pauldijou/redux-act/issues/53

I see two options to do that:

- check if the arg or some arg is a instance of error.
- allow another pararmeter in the function createAction, that will add the error key depending on the arguments received.

I chose the first one, but maybe the second one is the correct.

That way we could do something like this.

```
const networkResponse = createAction('NETWORK_RESPONSE', null, null, response => response.error);
const networkError = createAction('NETWORK_ERROR', null, null, () => true);

...

store.dispatch(networkError('error fetching user data');
store.dispatch(networkResponse(response);


```