### PR TITLE
Add default handler to Reducer.on()

### DIFF
--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -21,6 +21,9 @@ export default function createReducer(handlers = {}, defaultState) {
   }
 
   function on(typeOrActionCreator, handler) {
+    if (!handler) {
+      handler = (state, payload) => payload;
+    }
     if (Array.isArray(typeOrActionCreator)) {
       typeOrActionCreator.forEach(function (action) {
         on(action, handler)
@@ -72,7 +75,7 @@ export default function createReducer(handlers = {}, defaultState) {
     } else {
       return state;
     }
-  };
+  }
 
   return reducer;
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -147,6 +147,7 @@ interface Reducer<S> {
 
   options(opts: Object): Reducer<S>
   has(actionCreator: ActionCreatorOrString<any, any>): boolean
+  on<M={}>(actionCreator: ActionCreatorOrString<S, M>): Reducer<S>
   on<P, M={}>(actionCreator: ActionCreatorOrString<P, M>, handler: Handler<S, P, M>): Reducer<S>
   on<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M={}>(actionCreator: ActionCreatorOrString6<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M>, handler: Handler<S, P, M>): Reducer<S>
   on<Arg1, Arg2, Arg3, Arg4, Arg5, P, M={}>(actionCreator: ActionCreatorOrString5<Arg1, Arg2, Arg3, Arg4, Arg5, P, M>, handler: Handler<S, P, M>): Reducer<S>


### PR DESCRIPTION
Add `Reducer.on` that assumes that `Payload` type is the same as `State` and uses handler that simply returns payload as the new state.

It's useful with `combineReducers()` where the state slice is often the same as reducer payload.

If the PR is ok I'll add some tests.
