### PR TITLE
Added action's  empty object check

### DIFF
--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -7,6 +7,14 @@ function normalizeType(typeOrActionCreator) {
   return typeOrActionCreator;
 }
 
+function isEmptyObject (obj) {
+  for (const key in obj) {
+      if (obj.hasOwnProperty(key))
+          return false;
+  }
+  return true;
+}
+
 export default function createReducer(handlers = {}, defaultState) {
   const opts = {
     payload: true,
@@ -64,7 +72,7 @@ export default function createReducer(handlers = {}, defaultState) {
   }
 
   function reduce(state = defaultState, action) {
-    if (!action) { return state; }
+    if (!action || isEmptyObject(action)) { return state; }
     if (action.type.startsWith('@@redux/')) { return state; }
 
     const handler = handlers[action.type] || opts.fallback;

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -7,14 +7,6 @@ function normalizeType(typeOrActionCreator) {
   return typeOrActionCreator;
 }
 
-function isEmptyObject (obj) {
-  for (const key in obj) {
-      if (obj.hasOwnProperty(key))
-          return false;
-  }
-  return true;
-}
-
 export default function createReducer(handlers = {}, defaultState) {
   const opts = {
     payload: true,
@@ -72,7 +64,7 @@ export default function createReducer(handlers = {}, defaultState) {
   }
 
   function reduce(state = defaultState, action) {
-    if (!action || isEmptyObject(action)) { return state; }
+    if (!action || !action.type) { return state; }
     if (action.type.startsWith('@@redux/')) { return state; }
 
     const handler = handlers[action.type] || opts.fallback;

--- a/test/createReducerTest.js
+++ b/test/createReducerTest.js
@@ -45,6 +45,16 @@ describe('createReducer', function () {
     expect(secondReducer).to.be.a('function');
   });
 
+
+  it('should return the default state', function () {
+    const defaultState = 0;
+    const reducer = createReducer({}, defaultState);
+
+    expect(reducer(undefined, {})).to.be.equal(defaultState);
+    expect(reducer(undefined)).to.be.equal(defaultState);
+    expect(reducer()).to.be.equal(defaultState);
+  })
+
   it('should update a store', function () {
     const store = createStore(firstReducer, 0);
     store.dispatch(increment());

--- a/test/createReducerTest.js
+++ b/test/createReducerTest.js
@@ -53,7 +53,7 @@ describe('createReducer', function () {
     expect(reducer(undefined, {})).to.be.equal(defaultState);
     expect(reducer(undefined)).to.be.equal(defaultState);
     expect(reducer()).to.be.equal(defaultState);
-  })
+  });
 
   it('should update a store', function () {
     const store = createStore(firstReducer, 0);


### PR DESCRIPTION
Hey! I found a small difference with the examples of testing in the official redux documentation and your library.

[Here is an example](https://redux.js.org/docs/recipes/WritingTests.html#reducers) of testing the return of the reducer's initial state. This test implementation falls with redux-act reducer. I added a check on an empty action object and some related tests. 

I think it's better to keep full backward compatibility with original reducer.

