### PR TITLE
Fixes #76. IE 11 now runs library out of the box

### DIFF
--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -64,8 +64,12 @@ export default function createReducer(handlers = {}, defaultState) {
   }
 
   function reduce(state = defaultState, action) {
+    const prefix = "@@redux/";
+    const actionStartsWithPrefix = actionType => 
+      action.type.substring(0, prefix.length) === prefix
+      
     if (!action || (typeof action.type !== 'string')) { return state; }
-    if (action.type.startsWith('@@redux/')) { return state; }
+    if (actionStartsWithPrefix(action.type)) { return state; }
 
     const handler = handlers[action.type] || opts.fallback;
     if (handler) {


### PR DESCRIPTION
This PR introduces a small rework of a **reduce** function in **createReducers.js** that was using _String.startsWith_ method that is not supported in IE 11, now it works fine out of the box.