### PR TITLE
Fix misleading meta example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ doSomething(1); // { type: 'STRING_CONSTANT', payload: 1}
 
 // Little bonus, if you need to support metadata around your action,
 // like needed data but not really part of the payload, you add a second function
-const metaAction = createAction('desc', arg => arg, arg => ({meta: 'so meta!'}));
+const metaAction = createAction('desc', arg => arg, arg => 'so meta!');
 
 // Metadata will be the third argument of the reduce function
 createReducer({


### PR DESCRIPTION
The example usage of `meta` seems to imply that calling `createAction('desc', arg => arg, arg => ({ meta: 'so meta!' }));` would result in an action where the `meta` property was equal to `'so meta!'`, but running this actually gives me an action with `meta: { meta: 'so meta!' }`, which I imagine would never be the desired shape.

I think just having the result be `{ type, payload, meta: { 'so meta!' } }` is less misleading