### PR TITLE
Reorder reducer "on" function overloads in TypeScript types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -159,13 +159,13 @@ interface Reducer<S, A extends Redux.Action = Redux.AnyAction> {
 
   options(opts: Object): Reducer<S>
   has(actionCreator: ActionCreatorOrString<any, any>): boolean
-  on<P, M={}>(actionCreator: ActionCreatorOrString<P, M>, handler: Handler<S, P, M>): Reducer<S>
-  on<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M={}>(actionCreator: ActionCreatorOrString6<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M>, handler: Handler<S, P, M>): Reducer<S>
-  on<Arg1, Arg2, Arg3, Arg4, Arg5, P, M={}>(actionCreator: ActionCreatorOrString5<Arg1, Arg2, Arg3, Arg4, Arg5, P, M>, handler: Handler<S, P, M>): Reducer<S>
-  on<Arg1, Arg2, Arg3, Arg4, P, M={}>(actionCreator: ActionCreatorOrString4<Arg1, Arg2, Arg3, Arg4, P, M>, handler: Handler<S, P, M>): Reducer<S>
-  on<Arg1, Arg2, Arg3, P, M={}>(actionCreator: ActionCreatorOrString3<Arg1, Arg2, Arg3, P, M>, handler: Handler<S, P, M>): Reducer<S>
-  on<Arg1, Arg2, P, M={}>(actionCreator: ActionCreatorOrString2<Arg1, Arg2, P, M>, handler: Handler<S, P, M>): Reducer<S>
   on<Arg1, P, M={}>(actionCreator: ActionCreatorOrString1<Arg1, P, M>, handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, Arg2, P, M={}>(actionCreator: ActionCreatorOrString2<Arg1, Arg2, P, M>, handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, Arg2, Arg3, P, M={}>(actionCreator: ActionCreatorOrString3<Arg1, Arg2, Arg3, P, M>, handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, Arg2, Arg3, Arg4, P, M={}>(actionCreator: ActionCreatorOrString4<Arg1, Arg2, Arg3, Arg4, P, M>, handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, Arg2, Arg3, Arg4, Arg5, P, M={}>(actionCreator: ActionCreatorOrString5<Arg1, Arg2, Arg3, Arg4, Arg5, P, M>, handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M={}>(actionCreator: ActionCreatorOrString6<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M>, handler: Handler<S, P, M>): Reducer<S>
+  on<P, M={}>(actionCreator: ActionCreatorOrString<P, M>, handler: Handler<S, P, M>): Reducer<S>
   off(actionCreator: ActionCreatorOrString<any, any>): Reducer<S>
 }
 


### PR DESCRIPTION
Hi! 👋 

This PR just flips around the `on` overloads for `reducer`, so that the payload ends up being of the correct type in the reducer function.

For example, the following actions:
```typescript
createAction((a: "arg-1"): "return-1" => "return-1");
createAction((a: "arg-1", b: "arg-2"): "return-2" => "return-2");
createAction((a: "arg-1", b: "arg-2", c: "arg-3" ): "return-3" => "return-3");
createAction((a: "arg-1", b: "arg-2", c: "arg-3", d: "arg-4" ): "return-4" => "return-4");
createAction((a: "arg-1", b: "arg-2", c: "arg-3", d: "arg-4", e: "arg-5" ): "return-5" => "return-5");
createAction((a: "arg-1", b: "arg-2", c: "arg-3", d: "arg-4", e: "arg-5", f: "arg-6" ): "return-6" => "return-6");
createAction("PARAMS_1", (a: "arg-1"): "return-1" => "return-1");
createAction("PARAMS_2", (a: "arg-1", b: "arg-2"): "return-2" => "return-2");
createAction("PARAMS_3", (a: "arg-1", b: "arg-2", c: "arg-3" ): "return-3" => "return-3");
createAction("PARAMS_4", (a: "arg-1", b: "arg-2", c: "arg-3", d: "arg-4" ): "return-4" => "return-4");
createAction("PARAMS_5", (a: "arg-1", b: "arg-2", c: "arg-3", d: "arg-4", e: "arg-5" ): "return-5" => "return-5");
createAction("PARAMS_6", (a: "arg-1", b: "arg-2", c: "arg-3", d: "arg-4", e: "arg-5", f: "arg-6" ): "return-6" => "return-6");
```
<img width="1049" alt="6 actions with increasing amount of arguments" src="https://user-images.githubusercontent.com/419948/60097243-46f43500-9753-11e9-9d27-cfef80fbee64.png">
<img width="1134" alt="Screen Shot 2019-06-25 at 13 45 46" src="https://user-images.githubusercontent.com/419948/60097513-d699e380-9753-11e9-811b-76ce8e0dfc25.png">


Always used to hit the first overload:
```typescript
on<P, M={}>(actionCreator: ActionCreatorOrString<P, M>, handler: Handler<S, P, M>): Reducer<S>
```
I presume as it was the first one and seemingly it matched every version of the action, resulting in the `payload` being `any` for the actions with no description, and the following for the actions with description:
<img width="684" alt="payload-before" src="https://user-images.githubusercontent.com/419948/60097597-fd581a00-9753-11e9-8ae1-caa5838ce0fb.png">

With the change in this PR, these actions now hit their respective argument-count overloads and it results in the payloads for all the actions listed above, being the return types of the payload creator function, which I assume they intended to be in the first place:
<img width="628" alt="payload-after" src="https://user-images.githubusercontent.com/419948/60097689-2f697c00-9754-11e9-9b04-fbdbe2909ade.png">

As I'm no wizard, this could probably be done simpler or better with some of the newer features of TypeScript.