### PR TITLE
Support passing multiple action creators for reducer 'on' listener in TS

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -159,12 +159,12 @@ interface Reducer<S, A extends Redux.Action = Redux.AnyAction> {
 
   options(opts: Object): Reducer<S>
   has(actionCreator: ActionCreatorOrString<any, any>): boolean
-  on<Arg1, P, M={}>(actionCreator: ActionCreatorOrString1<Arg1, P, M>, handler: Handler<S, P, M>): Reducer<S>
-  on<Arg1, Arg2, P, M={}>(actionCreator: ActionCreatorOrString2<Arg1, Arg2, P, M>, handler: Handler<S, P, M>): Reducer<S>
-  on<Arg1, Arg2, Arg3, P, M={}>(actionCreator: ActionCreatorOrString3<Arg1, Arg2, Arg3, P, M>, handler: Handler<S, P, M>): Reducer<S>
-  on<Arg1, Arg2, Arg3, Arg4, P, M={}>(actionCreator: ActionCreatorOrString4<Arg1, Arg2, Arg3, Arg4, P, M>, handler: Handler<S, P, M>): Reducer<S>
-  on<Arg1, Arg2, Arg3, Arg4, Arg5, P, M={}>(actionCreator: ActionCreatorOrString5<Arg1, Arg2, Arg3, Arg4, Arg5, P, M>, handler: Handler<S, P, M>): Reducer<S>
-  on<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M={}>(actionCreator: ActionCreatorOrString6<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M>, handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, P, M={}>(actionCreator: ActionCreatorOrString1<Arg1, P, M> | ActionCreatorOrString1<Arg1, P, M>[], handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, Arg2, P, M={}>(actionCreator: ActionCreatorOrString2<Arg1, Arg2, P, M> | ActionCreatorOrString2<Arg1, Arg2, P, M>[], handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, Arg2, Arg3, P, M={}>(actionCreator: ActionCreatorOrString3<Arg1, Arg2, Arg3, P, M> | ActionCreatorOrString3<Arg1, Arg2, Arg3, P, M>[], handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, Arg2, Arg3, Arg4, P, M={}>(actionCreator: ActionCreatorOrString4<Arg1, Arg2, Arg3, Arg4, P, M> | ActionCreatorOrString4<Arg1, Arg2, Arg3, Arg4, P, M>[], handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, Arg2, Arg3, Arg4, Arg5, P, M={}>(actionCreator: ActionCreatorOrString5<Arg1, Arg2, Arg3, Arg4, Arg5, P, M> | ActionCreatorOrString5<Arg1, Arg2, Arg3, Arg4, Arg5, P, M>[], handler: Handler<S, P, M>): Reducer<S>
+  on<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M={}>(actionCreator: ActionCreatorOrString6<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M> | ActionCreatorOrString6<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, P, M>[], handler: Handler<S, P, M>): Reducer<S>
   on<P, M={}>(actionCreator: ActionCreatorOrString<P, M>, handler: Handler<S, P, M>): Reducer<S>
   off(actionCreator: ActionCreatorOrString<any, any>): Reducer<S>
 }


### PR DESCRIPTION
We already have the ability to pass multiple ActionCreators for the [Reducer 'on' listener](https://github.com/pauldijou/redux-act/blob/master/src/createReducer.js#L24), but the types were failing.
This PR fixes the types to allow for the existing feature.
 