### PR TITLE
Make namespaced action types serializable

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -35,7 +35,7 @@ export default function createAction(description, payloadReducer, metaReducer) {
     metaReducer = undefined;
   }
 
-  const isSerializable = (typeof description === 'string') && /^[0-9A-Z_]+$/.test(description);
+  const isSerializable = (typeof description === 'string') && /^[0-9A-Z_\/]+[^\/]+$/g.test(description);
 
   if (isSerializable) {
     check(description);


### PR DESCRIPTION
It's often necessary to define an action namespace using the '/' delimiter.
For example, `USER_DATA/FETCH_REQUESTED`